### PR TITLE
Fix budget weekly budget/expense reset errors, redo junit test

### DIFF
--- a/src/main/java/seedu/navi/budget/Budget.java
+++ b/src/main/java/seedu/navi/budget/Budget.java
@@ -25,7 +25,6 @@ public class Budget {
 
     public Budget() {
         loadBudgetData();
-        resetIfNeeded();
     }
 
     public static void setFilePath(String path) {
@@ -34,6 +33,9 @@ public class Budget {
 
     public void resetIfNeeded() {
         LocalDate today = getCurrentDate();
+        if (lastUpdatedDate == null || isNewWeek(lastUpdatedDate, today)) {
+            weeklyExpenses = 0; // Reset weekly expenses
+        }
         if (lastUpdatedDate == null || !today.equals(lastUpdatedDate)) {
             if (lastUpdatedDate == null || !today.getMonth().equals(lastUpdatedDate.getMonth())) {
                 monthlyExpenses = 0; // Reset monthly spending
@@ -48,7 +50,6 @@ public class Budget {
         if (!carryOver) {
             weeklyBudget = 0;
         }
-        weeklyExpenses = 0; // Reset weekly expenses
         saveBudgetData();
     }
 
@@ -172,13 +173,14 @@ public class Budget {
         this.lastUpdatedDate = lastUpdatedDate;
     }
 
-    public boolean isNewWeek(LocalDate today) {
+
+    public boolean isNewWeek(LocalDate lastUpdatedDate, LocalDate today) {
         if (lastUpdatedDate == null) {
             return true;
         }
         int currentWeek = today.get(WeekFields.of(Locale.getDefault()).weekOfYear());
-        int lastUpdatedWeek = lastUpdatedDate.get(WeekFields.of(Locale.getDefault()).weekOfYear());
-        return currentWeek != lastUpdatedWeek;
+        int lastWeek = lastUpdatedDate.get(WeekFields.of(Locale.getDefault()).weekOfYear());
+        return currentWeek != lastWeek || today.getYear() != lastUpdatedDate.getYear();
     }
 
 

--- a/src/main/java/seedu/navi/budget/BudgetParser.java
+++ b/src/main/java/seedu/navi/budget/BudgetParser.java
@@ -14,21 +14,28 @@ public class BudgetParser {
 
     public static void start() {
         scanner = new Scanner(System.in);
-        budget.resetIfNeeded(); // Check if a reset is needed (daily, weekly, monthly)
 
         LocalDate today = LocalDate.now();
         LocalDate lastUpdated = budget.getLastUpdatedDate();
-        if (today.getDayOfWeek().getValue() == 1 &&budget.isNewWeek(today)) {
-            System.out.println("Do you want to carry over last week's remaining budget? (yes/no)");
+
+        if ((lastUpdated!=null) && (budget.isNewWeek(lastUpdated, today))) {
+            TextUi.printLineSeparator();
+            System.out.println("Do you want to carry over last week's remaining budget of $" + String.format("%.2f",
+                    budget.getWeeklyBudget()) + "? (yes/no)");
+            TextUi.printLineSeparator();
             System.out.print("> ");
             String response = scanner.nextLine().trim().toLowerCase();
             while (!response.equals("yes") && !response.equals("no")) {
+                TextUi.printLineSeparator();
                 System.out.println("Please enter 'yes' or 'no'.");
+                TextUi.printLineSeparator();
                 System.out.print("> ");
                 response = scanner.nextLine().trim().toLowerCase();
             }
-            budget.resetWeeklyBudget(response.equals("no"));
+            budget.resetWeeklyBudget(response.equals("yes"));
         }
+
+        budget.resetIfNeeded(); // Check if a reset is needed (daily, weekly, monthly)
 
         TextUi.printLineSeparator();
         System.out.println("Budget Tracker: Enter a command (add X, deduct X, view, exit)");


### PR DESCRIPTION
-changed logic of checking if its new week (doesnt have to be just monday) 
-changed the order of resetting expenses and budget (initially resetting weekly expense feature wasnt working, but now does)
-changed the junit test accordingly to new code logic